### PR TITLE
Fixing 24:00 issue on Chrome

### DIFF
--- a/Website/js/clock.js
+++ b/Website/js/clock.js
@@ -6,7 +6,7 @@ function getSetTime() {
     document.getElementById("clock").innerHTML = time.toLocaleString('en-US', {
         hour: 'numeric',
         minute: 'numeric',
-        hour12: !hours24
+        hourCycle: hours24 ? 'h23' : 'h12'
     });
     return time;
 }


### PR DESCRIPTION
Fixes 24 hours issue on Chrome ([reference](https://support.google.com/chrome/thread/29828561/chrome-80-shows-timestamp-24-xx-instead-of-00-00?hl=en)).

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/1151470/172027936-3f11ebb8-135c-4440-b014-abe8d4856a78.png">

(Should be 00:53 instead).